### PR TITLE
Markdown documentation compiler complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /local
+docs-compiler/full-content.json

--- a/bramble/object/entity.js
+++ b/bramble/object/entity.js
@@ -1,29 +1,30 @@
 // ENTITY COMPONENT SYSTEM ENTITY //
-/*::entityComponentSystem
-An entity represents a game object with a collection of instansiated components. Components can be added and removed at run time. Entities may contain multiple instances of the same component type if that component permits it. Unlike traditional game objects, entities should not contain game logic. Instead they should only contain data, which should be processed in a game system.
-implementation: partial
-*/
 class Entity {
+  /*:: entityComponentSystem
+  An entity represents a game object with a collection of instansiated components. Components can be added and removed at run time. Entities may contain multiple instances of the same component type if that component permits it. Unlike traditional game objects, entities should not contain game logic. Instead they should only contain data, which should be processed in a game system.
+  implementation: partial*/
 
-  /*::entityComponentSystem/Entity
-  Creates a new entity
-  */
-  constructor() {}
+  constructor() {
+    /*:: entityComponentSystem/Entity
+    Creates a new entity
+    implementation: none*/
 
-  /*::entityComponentSystem/Entity
-  Adds the given component to the entiy
-  argument: comp entityComponentSystem/Component The component that will be added to the entity
-  implementation: partial
-  */
+  }
+
   addComponent( comp ) {
+    /*:: entityComponentSystem/Entity
+    Adds the given component to the entiy
+    argument: comp entityComponentSystem/Component The component that will be added to the entity
+    implementation: partial*/
     this[comp.name] = comp;
     comp.parent = this;
   }
 
-  /*::entityComponentSystem/Entity
-  Removes the specified component from the entity
-  argument: comp entityComponentSystem/Component The component that will be removed from the entity
-  implementation: partial
-  */
-  removeComponent( compName ) { delete this[compName] }
+  removeComponent( compName ) {
+    /*:: entityComponentSystem/Entity
+    Removes the specified component from the entity
+    argument: comp entityComponentSystem/Component The component that will be removed from the entity
+    implementation: partial*/
+    delete this[compName]
+  }
 }

--- a/bramble/object/entity.js
+++ b/bramble/object/entity.js
@@ -1,7 +1,8 @@
 // ENTITY COMPONENT SYSTEM ENTITY //
 class Entity {
   /*:: entityComponentSystem
-  An entity represents a game object with a collection of instansiated components. Components can be added and removed at run time. Entities may contain multiple instances of the same component type if that component permits it. Unlike traditional game objects, entities should not contain game logic. Instead they should only contain data, which should be processed in a game system.
+  An entity represents a game object with a collection of instansiated components. Components can be added and removed at run time. Entities may contain multiple instances of the same component type if that component permits it.
+  Unlike traditional game objects, entities should not contain game logic. Instead they should only contain data, which should be processed in a game system.
   implementation: partial*/
 
   constructor() {

--- a/bramble/object/entity.js
+++ b/bramble/object/entity.js
@@ -1,11 +1,29 @@
 // ENTITY COMPONENT SYSTEM ENTITY //
+/*::entityComponentSystem
+An entity represents a game object with a collection of instansiated components. Components can be added and removed at run time. Entities may contain multiple instances of the same component type if that component permits it. Unlike traditional game objects, entities should not contain game logic. Instead they should only contain data, which should be processed in a game system.
+implementation: partial
+*/
 class Entity {
+
+  /*::entityComponentSystem/Entity
+  Creates a new entity
+  */
   constructor() {}
 
+  /*::entityComponentSystem/Entity
+  Adds the given component to the entiy
+  argument: comp entityComponentSystem/Component The component that will be added to the entity
+  implementation: partial
+  */
   addComponent( comp ) {
     this[comp.name] = comp;
     comp.parent = this;
   }
 
+  /*::entityComponentSystem/Entity
+  Removes the specified component from the entity
+  argument: comp entityComponentSystem/Component The component that will be removed from the entity
+  implementation: partial
+  */
   removeComponent( compName ) { delete this[compName] }
 }

--- a/docs-compiler/base-content.json
+++ b/docs-compiler/base-content.json
@@ -1,0 +1,12 @@
+{
+  "content": {
+    "entityComponentSystem": {
+      "kind": "system",
+      "description": "Bramble has a built in ECS. Entities are objects that inherit from the `Entity` class. Components are are objects that inherit from a child class of the 'Component' class"
+    },
+    "assetLoader": {
+      "kind": "system",
+      "description": "The asset loader is used to automatically track the loading of all of the game's image and sound assets."
+    }
+  }
+}

--- a/docs-compiler/compile-content.py
+++ b/docs-compiler/compile-content.py
@@ -1,42 +1,54 @@
 import json
 from pprint import pprint
 
-# Load inital content
+#    JavaScript doc string syntax
+#    /* parentContentPath
+#    Lines with no definition indicator (see following lines) are added to the content's decription
+#    Decription can be multi-line, and supports markdown
+#    argument: valueName valueType Markdown description of the argument
+#    return: valueName valueType Markdown description of the return value
+#    implementation: none/partial/complete
+#    */
+#
+#    Comment closer (*/) does not have to be on it's own line
+#    To indicate that method c belongs to class B of system a, the parent content path would be "a/B"
+
+# Load base content from file
 f = open( 'base-content.json' , 'r' )
-content = json.loads( f.read() )
+content = json.loads( f.read() ) # The json object representing all documented content
 f.close()
 
-# Parse code base for doc strings
+# List of files that should be searched for doc strings
 fileNames = [
-    # 'core/init.js',
-    # 'core/assets.js',
-    # 'core/state.js',
-    # 'core/loop.js',
-    # 'core/start.js',
-    # 'core/draw.js',
-    # 'core/input.js',
+    'core/init.js',
+    'core/assets.js',
+    'core/state.js',
+    'core/loop.js',
+    'core/start.js',
+    'core/draw.js',
+    'core/input.js',
 
-    # 'object/vector.js',
+    'object/vector.js',
     'object/entity.js',
-    # 'object/component.js',
+    'object/component.js',
 
-    # 'components.js',
+    'components.js',
 ]
 
-# For each file to be documented
+# For each file to be documented, load the file and scan each line looking for doc strings
 for fileName in fileNames:
+    parsing = False # Indicates if a doc string is currently being parsed
+    pLine = "" # The previous line of the file
+    item = {} # The item (e.g. class) currently being parsed
+    container = content # The container of the current item
+
     f = open( '../bramble/' + fileName , 'r' )
-    parsing = False
-    pLine = ""
 
-    item = {}
-    container = content
-
-    # For each line in the file
+    # Scan lines
     for line in f:
         sLine = line.strip()
 
-        # If currently parsing a doc string
+        # When parsing doc string
         if ( parsing ):
 
             # Check if parsing should finish
@@ -44,7 +56,7 @@ for fileName in fileNames:
                 parsing = False
                 sLine = sLine[:-2]
 
-            # Function argument
+            # Identify a function argument definition
             if ( sLine[:9] == 'argument:' ):
                 if ( 'arguments' not in item ): item['arguments'] = []
                 data = sLine[9:].strip()
@@ -59,41 +71,59 @@ for fileName in fileNames:
                     "description": description
                 })
 
-            # Implementation
+            # Identify a function return value definition
+            if ( sLine[:7] == 'return:' ):
+                if ( 'returns' not in item ): item['returns'] = []
+                data = sLine[9:].strip()
+                name = data[:data.find(' ')]
+                data = data[data.find(' ')+1:]
+                type = data[:data.find(' ')]
+                data = data[data.find(' ')+1:]
+                description = data
+                item['returns'].append({
+                    "name": name,
+                    "type": type,
+                    "description": description
+                })
+
+            # Identify an implementation definition
             elif ( sLine[:15] == 'implementation:' ):
                 item['implementation'] = sLine[15:].strip()
 
-            # Description
+            # Description definition
             else:
-                item['description'] = sLine
+                if ( 'description' not in item ): item['description'] = sLine
+                else: item['description'] += '\n' + sLine
 
-        # If a doc string has been started
+        # When starting new doc string
         elif ( sLine[:4] == '/*::' ):
-                parsing = True
-                item = {}
-                container = content
-                for contentName in sLine[4:].strip().split('/'):
-                    if ( 'content' not in container ): container['content'] = {}
-                    if ( contentName not in container['content'] ): container['content'][contentName] = {}
-                    container = container['content'][contentName]
+
+            # Reset parser
+            parsing = True
+            item = {}
+            container = content
+
+            # Navigate to new items's container
+            for contentName in sLine[4:].strip().split('/'):
+                if ( 'content' not in container ): container['content'] = {}
+                if ( contentName not in container['content'] ): container['content'][contentName] = {}
+                container = container['content'][contentName]
                 if ( 'content' not in container ): container['content'] = {}
 
-                # Set the name and kind of the current item
-                if ( pLine[:6] == 'class '):
-                    itemName = pLine[6:pLine.find(' ')-7]
-                    item['kind'] = 'class'
-                else: # Is a function/method
-                    itemName = pLine[:pLine.find('(')]
-                    item['kind'] = 'function'
+            # Set the name and kind of the current item based on the previous line
+            if ( pLine[:6] == 'class '):
+                itemName = pLine[6:pLine.find(' ')-7]
+                item['kind'] = 'class'
+            else: # Is a function/method
+                itemName = pLine[:pLine.find('(')]
+                item['kind'] = 'function'
+            container['content'][itemName] = item
 
-                print( itemName , item['kind'] )
-                container['content'][itemName] = item
-
-        # Remember the previous line in the next iteration
+        # Remember the previous line for the next iteration
         pLine = sLine
 
-# Test
-f = open( 'full-content.json' , 'w' )
-f.write( json.dumps(content , indent=2, sort_keys=True) )
+# Save complete content to file
+f = open( 'full-content.json' , 'w' ) # This file is include in .git-ignore. Run this script locally to see the result
+# f.write( json.dumps(content) )
+f.write( json.dumps(content , indent=2, sort_keys=True) ) # Replace line above with this one in order to pretty print JSON
 f.close()
-# print(json.dumps(content))

--- a/docs-compiler/compile-content.py
+++ b/docs-compiler/compile-content.py
@@ -1,5 +1,4 @@
 import json
-from pprint import pprint
 
 #    JavaScript doc string syntax
 #    /* parentContentPath
@@ -124,6 +123,6 @@ for fileName in fileNames:
 
 # Save complete content to file
 f = open( 'full-content.json' , 'w' ) # This file is include in .git-ignore. Run this script locally to see the result
-# f.write( json.dumps(content) )
-f.write( json.dumps(content , indent=2, sort_keys=True) ) # Replace line above with this one in order to pretty print JSON
+f.write( json.dumps(content) )
+# f.write( json.dumps(content , indent=2, sort_keys=True) ) # Replace line above with this one in order to pretty print JSON
 f.close()

--- a/docs-compiler/compile-content.py
+++ b/docs-compiler/compile-content.py
@@ -1,0 +1,99 @@
+import json
+from pprint import pprint
+
+# Load inital content
+f = open( 'base-content.json' , 'r' )
+content = json.loads( f.read() )
+f.close()
+
+# Parse code base for doc strings
+fileNames = [
+    # 'core/init.js',
+    # 'core/assets.js',
+    # 'core/state.js',
+    # 'core/loop.js',
+    # 'core/start.js',
+    # 'core/draw.js',
+    # 'core/input.js',
+
+    # 'object/vector.js',
+    'object/entity.js',
+    # 'object/component.js',
+
+    # 'components.js',
+]
+
+# For each file to be documented
+for fileName in fileNames:
+    f = open( '../bramble/' + fileName , 'r' )
+    parsing = False
+    getName = False;
+
+    item = {}
+    container = content
+
+    # For each line in the file
+    for line in f:
+        sLine = line.strip()
+
+        # Set the name and kind of the current item
+        if ( getName ):
+
+            # Is a class
+            if ( sLine[:6] == 'class '):
+                itemName = sLine[6:sLine.find(' ')-7]
+                item['kind'] = 'class'
+            else:
+                itemName = sLine[:sLine.find('(')]
+                item['kind'] = 'function'
+            container['content'][itemName] = item
+            getName = False;
+
+        # If currently parsing a doc string
+        elif ( parsing ):
+
+            # Check if parsing should finish
+            if ( sLine[:2] == '*/' ):
+                parsing = False
+                getName = True;
+                sLine = sLine[::2]
+
+            # Function argument
+            if ( sLine[:9] == 'argument:' ):
+                if ( 'arguments' not in item ): item['arguments'] = []
+                data = sLine[9:].strip()
+                name = data[:data.find(' ')]
+                data = data[data.find(' ')+1:]
+                type = data[:data.find(' ')]
+                data = data[data.find(' ')+1:]
+                description = data
+                item['arguments'].append({
+                    "name": name,
+                    "type": type,
+                    "description": description
+                })
+
+            # Implementation
+            elif ( sLine[:15] == 'implementation:' ):
+                item['implementation'] = sLine[15:].strip()
+
+            # Description
+            else:
+                item['description'] = sLine
+
+        # If a doc string has been started
+        elif ( sLine[:4] == '/*::' ):
+                parsing = True
+                item = {}
+                container = content
+                for contentName in sLine[4:].strip().split('/'):
+                    if ( 'content' not in container ): container['content'] = {}
+                    if ( contentName not in container['content'] ): container['content'][contentName] = {}
+                    container = container['content'][contentName]
+                if ( 'content' not in container ): container['content'] = {}
+
+# Test
+f = open( 'full-content.json' , 'w' )
+f.write( json.dumps(content , indent=2, sort_keys=True) )
+f.close()
+# print(json.dumps(content))

--- a/docs-compiler/compile-content.py
+++ b/docs-compiler/compile-content.py
@@ -37,7 +37,7 @@ fileNames = [
 # For each file to be documented, load the file and scan each line looking for doc strings
 for fileName in fileNames:
     parsing = False # Indicates if a doc string is currently being parsed
-    pLine = "" # The previous line of the file
+    pLine = '' # The previous line of the file
     item = {} # The item (e.g. class) currently being parsed
     container = content # The container of the current item
 
@@ -65,9 +65,9 @@ for fileName in fileNames:
                 data = data[data.find(' ')+1:]
                 description = data
                 item['arguments'].append({
-                    "name": name,
-                    "type": type,
-                    "description": description
+                    'name': name,
+                    'type': type,
+                    'description': description
                 })
 
             # Identify a function return value definition
@@ -80,9 +80,9 @@ for fileName in fileNames:
                 data = data[data.find(' ')+1:]
                 description = data
                 item['returns'].append({
-                    "name": name,
-                    "type": type,
-                    "description": description
+                    'name': name,
+                    'type': type,
+                    'description': description
                 })
 
             # Identify an implementation definition

--- a/docs-compiler/compile-content.py
+++ b/docs-compiler/compile-content.py
@@ -27,7 +27,7 @@ fileNames = [
 for fileName in fileNames:
     f = open( '../bramble/' + fileName , 'r' )
     parsing = False
-    getName = False;
+    pLine = ""
 
     item = {}
     container = content
@@ -36,27 +36,13 @@ for fileName in fileNames:
     for line in f:
         sLine = line.strip()
 
-        # Set the name and kind of the current item
-        if ( getName ):
-
-            # Is a class
-            if ( sLine[:6] == 'class '):
-                itemName = sLine[6:sLine.find(' ')-7]
-                item['kind'] = 'class'
-            else:
-                itemName = sLine[:sLine.find('(')]
-                item['kind'] = 'function'
-            container['content'][itemName] = item
-            getName = False;
-
         # If currently parsing a doc string
-        elif ( parsing ):
+        if ( parsing ):
 
             # Check if parsing should finish
-            if ( sLine[:2] == '*/' ):
+            if ( sLine[-2:] == '*/' ):
                 parsing = False
-                getName = True;
-                sLine = sLine[::2]
+                sLine = sLine[:-2]
 
             # Function argument
             if ( sLine[:9] == 'argument:' ):
@@ -91,6 +77,20 @@ for fileName in fileNames:
                     if ( contentName not in container['content'] ): container['content'][contentName] = {}
                     container = container['content'][contentName]
                 if ( 'content' not in container ): container['content'] = {}
+
+                # Set the name and kind of the current item
+                if ( pLine[:6] == 'class '):
+                    itemName = pLine[6:pLine.find(' ')-7]
+                    item['kind'] = 'class'
+                else: # Is a function/method
+                    itemName = pLine[:pLine.find('(')]
+                    item['kind'] = 'function'
+
+                print( itemName , item['kind'] )
+                container['content'][itemName] = item
+
+        # Remember the previous line in the next iteration
+        pLine = sLine
 
 # Test
 f = open( 'full-content.json' , 'w' )

--- a/docs-compiler/compile-content.py
+++ b/docs-compiler/compile-content.py
@@ -71,7 +71,7 @@ for fileName in fileNames:
                 })
 
             # Identify a function return value definition
-            if ( sLine[:7] == 'return:' ):
+            elif ( sLine[:7] == 'return:' ):
                 if ( 'returns' not in item ): item['returns'] = []
                 data = sLine[9:].strip()
                 name = data[:data.find(' ')]
@@ -123,6 +123,5 @@ for fileName in fileNames:
 
 # Save complete content to file
 f = open( 'full-content.json' , 'w' ) # This file is include in .git-ignore. Run this script locally to see the result
-f.write( json.dumps(content) )
-# f.write( json.dumps(content , indent=2, sort_keys=True) ) # Replace line above with this one in order to pretty print JSON
+f.write( json.dumps(content , indent=2, sort_keys=True) )
 f.close()

--- a/docs-compiler/compile-markdown.py
+++ b/docs-compiler/compile-markdown.py
@@ -6,6 +6,11 @@ f = open( 'full-content.json' , 'r' ) # This file is include in .git-ignore
 content = json.loads( f.read() ) # The json object representing all documented content
 f.close()
 
+# Function to convert a string from camel case to a capitalised string
+# e.g. "entityComponentSystem" -> "Entity Component System"
+def deCamelCase( s ):
+    return re.sub( r'(.)([A-Z])',r'\1 \2',s).title()
+
 # Function to compile a system content item into markdown
 def compileSystem( systemName , systemItem ):
     if ( systemItem['kind'] != 'system' ): raise RuntimeError( 'Cannot compile "' + systemName + '" as a system as it is if of type "' + systemItem['kind'] + '"' )
@@ -47,7 +52,7 @@ def compileSystem( systemName , systemItem ):
                 raise RuntimeError( 'Cannot compile ' + item['kind'] + ' "' + itemName + '" (content of system "' + systemName + '") as it is not a function or class' )
 
     # Output final result
-    finalMd = '\n# ' + systemName + '\n'
+    finalMd = '\n# ' + deCamelCase(systemName) + '\n'
     if ( 'description' in systemItem ): finalMd += systemItem['description'] + '\n'
     if ( areFunctions ): finalMd += functionsMd + '\n'
     if ( areClasses ): finalMd += classesMd + '\n'

--- a/docs-compiler/compile-markdown.py
+++ b/docs-compiler/compile-markdown.py
@@ -8,9 +8,7 @@ f.close()
 
 # Function to compile a system content item into markdown
 def compileSystem( systemName , systemItem ):
-    if ( systemItem['kind'] != 'system' ):
-        print( 'notice: Cannot compile "' + systemName + '" as it is not a system' )
-        return ''
+    if ( systemItem['kind'] != 'system' ): raise RuntimeError( 'Cannot compile "' + systemName + '" as a system as it is if of type "' + systemItem['kind'] + '"' )
 
     functionsMd = '\n## Functions\n'
     areFunctions = False
@@ -42,11 +40,11 @@ def compileSystem( systemName , systemItem ):
                         if ( subItem['kind'] == 'function' ):
                             classesMd += compileFunction( itemName + '.' + subItemName , subItem , 4 )
                         else:
-                            print( 'notice: Cannot compile "' + subItemName + '" as it is not a function' )
+                            raise RuntimeError( 'Cannot compile ' + subItem['kind'] + ' "' + subItemName + '" (content of system "' + itemName + '") as it is not a function (method)' )
 
             # Item is of invalid kind
             else:
-                print( 'notice: Cannot compile "' + itemName + '" as it is not a function or class' )
+                raise RuntimeError( 'Cannot compile ' + item['kind'] + ' "' + itemName + '" (content of system "' + systemName + '") as it is not a function or class' )
 
     # Output final result
     finalMd = '\n# ' + systemName + '\n'
@@ -58,6 +56,7 @@ def compileSystem( systemName , systemItem ):
 
 # Function to compile function content item into markdown
 def compileFunction( functName , functItem , level=1 ):
+    if ( functItem['kind'] != 'function' ): raise RuntimeError( 'Cannot compile "' + functName + '" as a function as it is if of type "' + functItem['kind'] + '"' )
 
     # Basic overview
     finalMd = '\n' + '#'*(level) + ' ' + functName + '\n'
@@ -68,7 +67,7 @@ def compileFunction( functName , functItem , level=1 ):
         # finalMd += '\n' + '#'*(level+1) + ' Arguments\n'
         finalMd += '\n**Arguments**\n'
 
-        finalMd += '\n| Data Type | Name | Description |\n| --- | --- | --- |\n' # Blank line is required before a table so that GitHub can render it
+        finalMd += '\n| Data Type | Name | Description |\n| :--- | :--- | :--- |\n' # Blank line is required before a table so that GitHub can render it
         for arg in functItem['arguments']: finalMd += '| `' + arg['type'] + '` | `' + arg['name'] + '` | ' + arg['description'] + ' |\n'
 
     # Return values
@@ -76,7 +75,7 @@ def compileFunction( functName , functItem , level=1 ):
         # finalMd += '\n' + '#'*(level+1) + ' Returns\n'
         finalMd += '\n**Returns**\n'
 
-        finalMd += '\n| Data Type | Name | Description |\n| --- | --- | --- |' # Blank line is required before a table so that GitHub can render it
+        finalMd += '\n| Data Type | Name | Description |\n| :--- | :--- | :--- |' # Blank line is required before a table so that GitHub can render it
         for val in functItem['returns']: finalMd += '| `' + val['type'] + '` | `' + val['name'] + '` | ' + val['description'] + ' |\n'
 
     return finalMd

--- a/docs-compiler/compile-markdown.py
+++ b/docs-compiler/compile-markdown.py
@@ -68,7 +68,7 @@ def compileFunction( functName , functItem , level=1 ):
         # finalMd += '\n' + '#'*(level+1) + ' Arguments\n'
         finalMd += '\n**Arguments**\n'
 
-        finalMd += '\n' # Blank line is required before a table so that GitHub can render it
+        finalMd += '\n| Data Type | Name | Description |\n| --- | --- | --- |\n' # Blank line is required before a table so that GitHub can render it
         for arg in functItem['arguments']: finalMd += '| `' + arg['type'] + '` | `' + arg['name'] + '` | ' + arg['description'] + ' |\n'
 
     # Return values
@@ -76,7 +76,7 @@ def compileFunction( functName , functItem , level=1 ):
         # finalMd += '\n' + '#'*(level+1) + ' Returns\n'
         finalMd += '\n**Returns**\n'
 
-        finalMd += '\n' # Blank line is required before a table so that GitHub can render it
+        finalMd += '\n| Data Type | Name | Description |\n| --- | --- | --- |' # Blank line is required before a table so that GitHub can render it
         for val in functItem['returns']: finalMd += '| `' + val['type'] + '` | `' + val['name'] + '` | ' + val['description'] + ' |\n'
 
     return finalMd

--- a/docs-compiler/compile-markdown.py
+++ b/docs-compiler/compile-markdown.py
@@ -1,0 +1,93 @@
+import json
+import re
+
+# Load full content from file
+f = open( 'full-content.json' , 'r' ) # This file is include in .git-ignore
+content = json.loads( f.read() ) # The json object representing all documented content
+f.close()
+
+# Function to compile a system content item into markdown
+def compileSystem( systemName , systemItem ):
+    if ( systemItem['kind'] != 'system' ):
+        print( 'notice: Cannot compile "' + systemName + '" as it is not a system' )
+        return ''
+
+    functionsMd = '\n## Functions\n'
+    areFunctions = False
+    classesMd = '\n## Classes\n'
+    areClasses = False
+
+    # Iterate through system content
+    if ( 'content' in systemItem ):
+        for itemName in systemItem['content']:
+            item = systemItem['content'][itemName]
+
+            # Item is a function
+            if ( item['kind'] == 'function' ):
+                areFunctions = True
+                functionsMd += compileFunction( itemName , name , 3 )
+
+            # Item is a class
+            elif ( item['kind'] == 'class' ):
+                areClasses = True
+
+                # Basic overview
+                classesMd += '\n### ' + itemName + '\n'
+                if ( 'description' in item ): classesMd += re.sub( r'\n+' , '\n\n' , item['description'] ) + '\n'
+
+                # Methods
+                if ( 'content' in item ):
+                    for subItemName in item['content']:
+                        subItem = item['content'][subItemName]
+                        if ( subItem['kind'] == 'function' ):
+                            classesMd += compileFunction( itemName + '.' + subItemName , subItem , 4 )
+                        else:
+                            print( 'notice: Cannot compile "' + subItemName + '" as it is not a function' )
+
+            # Item is of invalid kind
+            else:
+                print( 'notice: Cannot compile "' + itemName + '" as it is not a function or class' )
+
+    # Output final result
+    finalMd = '\n# ' + systemName + '\n'
+    if ( 'description' in systemItem ): finalMd += systemItem['description'] + '\n'
+    if ( areFunctions ): finalMd += functionsMd + '\n'
+    if ( areClasses ): finalMd += classesMd + '\n'
+
+    return finalMd
+
+# Function to compile function content item into markdown
+def compileFunction( functName , functItem , level=1 ):
+
+    # Basic overview
+    finalMd = '\n' + '#'*(level) + ' ' + functName + '\n'
+    if ( 'description' in functItem ): finalMd += re.sub( r'\n+' , '\n\n' , functItem['description'] ) + '\n'
+
+    # Arguments
+    if ( 'arguments' in functItem ):
+        # finalMd += '\n' + '#'*(level+1) + ' Arguments\n'
+        finalMd += '\n**Arguments**\n'
+
+        finalMd += '\n' # Blank line is required before a table so that GitHub can render it
+        for arg in functItem['arguments']: finalMd += '| `' + arg['type'] + '` | `' + arg['name'] + '` | ' + arg['description'] + ' |\n'
+
+    # Return values
+    if ( 'returns' in functItem ):
+        # finalMd += '\n' + '#'*(level+1) + ' Returns\n'
+        finalMd += '\n**Returns**\n'
+
+        finalMd += '\n' # Blank line is required before a table so that GitHub can render it
+        for val in functItem['returns']: finalMd += '| `' + val['type'] + '` | `' + val['name'] + '` | ' + val['description'] + ' |\n'
+
+    return finalMd
+
+# Compile all systems in the root content
+docMd = ''
+for systemName in content['content']:
+    docMd += compileSystem( systemName , content['content'][systemName] )
+docMd = docMd.strip()
+
+# Save complete markdown to file
+f = open( 'documentation.md' , 'w' )
+f.write( docMd )
+f.close()

--- a/docs-compiler/documentation.md
+++ b/docs-compiler/documentation.md
@@ -14,8 +14,6 @@ Unlike traditional game objects, entities should not contain game logic. Instead
 #### Entity.addComponent
 Adds the given component to the entiy
 
-argument: comp entityComponentSystem/Component The component that will be added to the entity
-
 **Arguments**
 
 | Data Type | Name | Description |
@@ -27,8 +25,6 @@ Creates a new entity
 
 #### Entity.removeComponent
 Removes the specified component from the entity
-
-argument: comp entityComponentSystem/Component The component that will be removed from the entity
 
 **Arguments**
 

--- a/docs-compiler/documentation.md
+++ b/docs-compiler/documentation.md
@@ -1,0 +1,33 @@
+# assetLoader
+The asset loader is used to automatically track the loading of all of the game's image and sound assets.
+
+# entityComponentSystem
+Bramble has a built in ECS. Entities are objects that inherit from the `Entity` class. Components are are objects that inherit from a child class of the 'Component' class
+
+## Classes
+
+### Entity
+An entity represents a game object with a collection of instansiated components. Components can be added and removed at run time. Entities may contain multiple instances of the same component type if that component permits it.
+
+Unlike traditional game objects, entities should not contain game logic. Instead they should only contain data, which should be processed in a game system.
+
+#### Entity.addComponent
+Adds the given component to the entiy
+
+argument: comp entityComponentSystem/Component The component that will be added to the entity
+
+**Arguments**
+
+| `entityComponentSystem/Component` | `comp` | The component that will be added to the entity |
+
+#### Entity.constructor
+Creates a new entity
+
+#### Entity.removeComponent
+Removes the specified component from the entity
+
+argument: comp entityComponentSystem/Component The component that will be removed from the entity
+
+**Arguments**
+
+| `entityComponentSystem/Component` | `comp` | The component that will be removed from the entity |

--- a/docs-compiler/documentation.md
+++ b/docs-compiler/documentation.md
@@ -1,7 +1,7 @@
-# assetLoader
+# Asset Loader
 The asset loader is used to automatically track the loading of all of the game's image and sound assets.
 
-# entityComponentSystem
+# Entity Component System
 Bramble has a built in ECS. Entities are objects that inherit from the `Entity` class. Components are are objects that inherit from a child class of the 'Component' class
 
 ## Classes

--- a/docs-compiler/documentation.md
+++ b/docs-compiler/documentation.md
@@ -19,7 +19,7 @@ argument: comp entityComponentSystem/Component The component that will be added 
 **Arguments**
 
 | Data Type | Name | Description |
-| --- | --- | --- |
+| :--- | :--- | :--- |
 | `entityComponentSystem/Component` | `comp` | The component that will be added to the entity |
 
 #### Entity.constructor
@@ -33,5 +33,5 @@ argument: comp entityComponentSystem/Component The component that will be remove
 **Arguments**
 
 | Data Type | Name | Description |
-| --- | --- | --- |
+| :--- | :--- | :--- |
 | `entityComponentSystem/Component` | `comp` | The component that will be removed from the entity |

--- a/docs-compiler/documentation.md
+++ b/docs-compiler/documentation.md
@@ -18,6 +18,8 @@ argument: comp entityComponentSystem/Component The component that will be added 
 
 **Arguments**
 
+| Data Type | Name | Description |
+| --- | --- | --- |
 | `entityComponentSystem/Component` | `comp` | The component that will be added to the entity |
 
 #### Entity.constructor
@@ -30,4 +32,6 @@ argument: comp entityComponentSystem/Component The component that will be remove
 
 **Arguments**
 
+| Data Type | Name | Description |
+| --- | --- | --- |
 | `entityComponentSystem/Component` | `comp` | The component that will be removed from the entity |

--- a/docs-compiler/json-content-example.json
+++ b/docs-compiler/json-content-example.json
@@ -1,0 +1,20 @@
+{
+
+  "contentName": {
+    "kind": "system/function/class",
+    "description": "Stores a written decription of the the thing the object represents in markdown",
+    "implementation": "none/partial/complete",
+
+    "arguments": [
+      {
+        "name": "argumentName",
+        "type": "The data type",
+        "description": "An explaination of the argument"
+      }
+    ],
+    "returns": [],
+
+    "content": {}
+  }
+
+}


### PR DESCRIPTION
An inital documentation compiler has been complete. It scans specified JavaScript files for doc strings, that are then parsed into an arbitrary JSON format. This JSON format is then converted into a single file markdown document.

The intent behind the JSON intermediary step is that in future addtional scripts can be created that convert the documentation into different formats (e.g. HTML, multi-file mark down, etc).

The compiler has been written in two python scripts. The first converts doc strings to JSON, the second converts JSON to markdown.